### PR TITLE
Update documentation: change curvature units form degrees to 1 / map units

### DIFF
--- a/R/RSAGA-modules.R
+++ b/R/RSAGA-modules.R
@@ -459,16 +459,16 @@ rsaga.sgrd.to.esri = function( in.sgrds, out.grids, out.path,
 #' @param in.dem input: digital elevation model as SAGA grid file (`.sgrd`)
 #' @param out.slope optional output: slope
 #' @param out.aspect optional output: aspect
-#' @param out.cgene optional output: general curvature
-#' @param out.cprof optional output: profile curvature (vertical curvature; degrees)
-#' @param out.cplan optional output: plan curvature (horizontal curvature; degrees)
-#' @param out.ctang optional output: tangential curvature (degrees)
-#' @param out.clong optional output: longitudinal curvature (degrees) Zevenbergen & Thorne (1987) refer to this as profile curvature
-#' @param out.ccros optional output: cross-sectional curvature (degrees) Zevenbergen & Thorne (1987) refer to this as the plan curvature
-#' @param out.cmini optional output: minimal curvature (degrees)
-#' @param out.cmaxi optional output: maximal curvature (degrees)
-#' @param out.ctota optional output: total curvature (degrees)
-#' @param out.croto optional output: flow line curvature (degrees)
+#' @param out.cgene optional output: general curvature (1 / map units)
+#' @param out.cprof optional output: profile curvature (vertical curvature; 1 / map units)
+#' @param out.cplan optional output: plan curvature (horizontal curvature; 1 / map units)
+#' @param out.ctang optional output: tangential curvature (1 / map units)
+#' @param out.clong optional output: longitudinal curvature (1 / map units) Zevenbergen & Thorne (1987) refer to this as profile curvature
+#' @param out.ccros optional output: cross-sectional curvature (1 / map units) Zevenbergen & Thorne (1987) refer to this as the plan curvature
+#' @param out.cmini optional output: minimal curvature (1 / map units)
+#' @param out.cmaxi optional output: maximal curvature (1 / map units)
+#' @param out.ctota optional output: total curvature (1 / map units)
+#' @param out.croto optional output: flow line curvature (1 / map units)
 #' @param method character algorithm (see References):
 #' - 0 Maximum Slope - Travis et al. (1975) (`"maxslope"`)
 #' - 1 Max. Triangle Slope - Tarboton (1997) (`"maxtriangleslope"`)

--- a/man/rsaga.slope.asp.curv.Rd
+++ b/man/rsaga.slope.asp.curv.Rd
@@ -16,25 +16,25 @@ rsaga.slope.asp.curv(in.dem, out.slope, out.aspect, out.cgene, out.cprof,
 
 \item{out.aspect}{optional output: aspect}
 
-\item{out.cgene}{optional output: general curvature}
+\item{out.cgene}{optional output: general curvature (1 / map units)}
 
-\item{out.cprof}{optional output: profile curvature (vertical curvature; degrees)}
+\item{out.cprof}{optional output: profile curvature (vertical curvature; 1 / map units)}
 
-\item{out.cplan}{optional output: plan curvature (horizontal curvature; degrees)}
+\item{out.cplan}{optional output: plan curvature (horizontal curvature; 1 / map units)}
 
-\item{out.ctang}{optional output: tangential curvature (degrees)}
+\item{out.ctang}{optional output: tangential curvature (1 / map units)}
 
-\item{out.clong}{optional output: longitudinal curvature (degrees) Zevenbergen & Thorne (1987) refer to this as profile curvature}
+\item{out.clong}{optional output: longitudinal curvature (1 / map units) Zevenbergen & Thorne (1987) refer to this as profile curvature}
 
-\item{out.ccros}{optional output: cross-sectional curvature (degrees) Zevenbergen & Thorne (1987) refer to this as the plan curvature}
+\item{out.ccros}{optional output: cross-sectional curvature (1 / map units) Zevenbergen & Thorne (1987) refer to this as the plan curvature}
 
-\item{out.cmini}{optional output: minimal curvature (degrees)}
+\item{out.cmini}{optional output: minimal curvature (1 / map units)}
 
-\item{out.cmaxi}{optional output: maximal curvature (degrees)}
+\item{out.cmaxi}{optional output: maximal curvature (1 / map units)}
 
-\item{out.ctota}{optional output: total curvature (degrees)}
+\item{out.ctota}{optional output: total curvature (1 / map units)}
 
-\item{out.croto}{optional output: flow line curvature (degrees)}
+\item{out.croto}{optional output: flow line curvature (1 / map units)}
 
 \item{method}{character algorithm (see References):
 \itemize{


### PR DESCRIPTION
Curvature values refer to a radius. Therefore all curvature values are in 1 / map units.  For a DEM in meters, the curvature unit is 1 / meters.  See also [SAGA GIS Forum](https://sourceforge.net/p/saga-gis/discussion/790705/thread/30c1dfe8/)